### PR TITLE
Add reset-all command

### DIFF
--- a/src/reloaded/repl.clj
+++ b/src/reloaded/repl.clj
@@ -1,6 +1,6 @@
 (ns reloaded.repl
   (:require [com.stuartsierra.component :as component]
-            [clojure.tools.namespace.repl :refer [disable-reload! refresh]]
+            [clojure.tools.namespace.repl :refer [disable-reload! refresh refresh-all]]
             [suspendable.core :as suspendable]))
 
 (disable-reload!)
@@ -51,3 +51,7 @@
 (defn reset []
   (suspend)
   (refresh :after 'reloaded.repl/resume))
+
+(defn reset-all []
+  (suspend)
+  (refresh-all :after 'reloaded.repl/resume))


### PR DESCRIPTION
This command works like `reset`, except it reloads every namespace in your project, even if it hasn't changed.

I usually use this on projects where I use YeSQL. YeSQL creates functions based on non-.clj files, which aren't picked up unless the file containing the YeSQL macro is changed as well (which usually never happens).
