### PR TITLE
Add support for boot build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Add the following dependency to your dev profile:
 
     [reloaded.repl "0.2.3"]
 
+boot uses additionally need one more dependency:
+
+    [boot/core "x.y.z"]
+
+were "x.y.z" is the boot version.
+
 ## Usage
 
 Require the `reloaded.repl` namespace in your user.clj file, and use

--- a/src/reloaded/repl.clj
+++ b/src/reloaded/repl.clj
@@ -1,6 +1,6 @@
 (ns reloaded.repl
   (:require [com.stuartsierra.component :as component]
-            [clojure.tools.namespace.repl :refer [disable-reload! refresh refresh-all]]
+            [clojure.tools.namespace.repl :refer [disable-reload! refresh refresh-all set-refresh-dirs]]
             [suspendable.core :as suspendable]))
 
 (disable-reload!)
@@ -8,6 +8,13 @@
 (def system nil)
 
 (def initializer nil)
+
+(try
+  (require 'boot.core)
+  (let [get-env (ns-resolve (symbol "boot.core") (symbol "get-env"))
+        dirs (get-env :directories)]
+    (apply set-refresh-dirs dirs))
+  (catch Throwable _))
 
 (defn set-init! [init]
   (alter-var-root #'initializer (constantly init)))


### PR DESCRIPTION
boot stores artifacts in global cache directory therefore we need to
set refresh directories proprietary.