### PR TITLE
Don't hide the start exception when failing to start and stop

### DIFF
--- a/src/reloaded/repl.clj
+++ b/src/reloaded/repl.clj
@@ -31,8 +31,9 @@
         (component/stop (:system (ex-data start-ex)))
         (catch Throwable stop-ex
           (throw (ex-info "System failed during start, also failed to stop failed system"
-                          {:start-exception start-ex}
-                          stop-ex))))
+                          {:start-exception start-ex
+                           :stop-ex stop-ex}
+                          start-ex))))
       (throw start-ex))))
 
 (defn start []


### PR DESCRIPTION
When failing to start the system, the start exception is more interesting than
the stop exception. This change prioritizes start-ex over stop-ex in the
exception cause chain.

The start-exception is still included in the ex-data, to avoid breaking any code
expecting to find it there.